### PR TITLE
Change port used by Chrome in acceptance tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-grants-frontend",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "Frontend Grants microservice.",
   "main": "app/index.js",
   "scripts": {

--- a/test/acceptance/docker-compose.override.yaml
+++ b/test/acceptance/docker-compose.override.yaml
@@ -19,7 +19,7 @@ services:
 
   selenium:
     ports:
-      - "9001:5900"
+      - "5900:5900"
 
   hub:
     ports:


### PR DESCRIPTION
Fix issue with laptop that blocks port 9001 that was previously used