### PR TITLE
Fixed logic issue with ga4 scoreReached parameter

### DIFF
--- a/app/helpers/handlers.js
+++ b/app/helpers/handlers.js
@@ -135,6 +135,8 @@ const showPostPage = (currentQuestion, request, h) => {
   const NOT_ELIGIBLE = { ...ineligibleContent, backLink: baseUrl }
   const payload = request.payload
 
+  setYarValue(request, 'onScorePage', false)
+
   let thisAnswer
   let dataObject
 
@@ -233,7 +235,6 @@ const processGA = async (question, request) => {
       await gapiService.sendGAEvent(request, question.ga)
     }
   }
-  setYarValue(request, 'onScorePage', false)
 
 }
 

--- a/app/routes/water-source.js
+++ b/app/routes/water-source.js
@@ -164,6 +164,8 @@ module.exports = [
         setYarValue(request, 'summerAbstractChange', null)
         setYarValue(request, 'mainsChange', null)
 
+        setYarValue(request, 'onScorePage', false)
+
         return h.redirect(nextPath)
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-grants-frontend",
-  "version": "3.11.4",
+  "version": "3.11.5",
   "description": "Frontend Grants microservice.",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
Data is sent only for immediate page after score page

There is also data sent when on the score page, however this is not an issue for reporting etc